### PR TITLE
Potential fix for code scanning alert no. 4: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/Blog/Platform/User/Config/SecurityConfig.java
+++ b/src/main/java/com/Blog/Platform/User/Config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -44,7 +45,10 @@ public class SecurityConfig {
 
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .ignoringRequestMatchers("/ws/chat/**")
+                )
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/user/signup",


### PR DESCRIPTION
Potential fix for [https://github.com/06Rahul/Blog/security/code-scanning/4](https://github.com/06Rahul/Blog/security/code-scanning/4)

In general, the fix is to stop globally disabling CSRF and instead either (a) re-enable CSRF protection with an appropriate token repository for browser clients or (b) if this is truly a stateless JWT-only API, document and constrain that assumption and selectively ignore the finding. To align with secure defaults and without changing the externally observable behavior of authentication (JWT-based), we can re-enable CSRF while configuring it in a way that does not interfere with JWT auth and still protects browser-based state-changing requests.

The single best fix, with minimal functional change, is:
- Remove `csrf.disable()` and replace it with an explicit CSRF configuration that:
  - Enables CSRF by default.
  - Ignores CSRF for clearly non-browser or special endpoints (e.g., `/ws/chat/**` if appropriate).
  - Uses a cookie-based CSRF token repository (`CookieCsrfTokenRepository.withHttpOnlyFalse()`) so that a front-end SPA can read and send the token in headers.
- Keep the rest of the filter chain (CORS, stateless session, JWT filter) unchanged.

Concretely in `src/main/java/com/Blog/Platform/User/Config/SecurityConfig.java`:
1. Add an import for `org.springframework.security.web.csrf.CookieCsrfTokenRepository;`.
2. Replace the line `.csrf(csrf -> csrf.disable())` with something like:
   ```java
   .csrf(csrf -> csrf
           .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
           .ignoringRequestMatchers("/ws/chat/**")
   )
   ```
   Adjusting `ignoringRequestMatchers` only for endpoints that genuinely need to bypass CSRF (here, I use the WebSocket path since it typically does not need CSRF).
This preserves stateless JWT authentication while re-enabling CSRF for normal browser requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
